### PR TITLE
[TASK] Add .ddev to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .Build
+.ddev
 .idea
 .phpunit.result.cache
 composer.lock


### PR DESCRIPTION
This folder should never be committed, however I personally like to use it for the correct PHP versions and extensions to be loaded.