### PR TITLE
Allow URLs with relative protocol

### DIFF
--- a/Classes/Hooks/PageRenderer/TrackingCodeInjector.php
+++ b/Classes/Hooks/PageRenderer/TrackingCodeInjector.php
@@ -81,7 +81,7 @@ final class TrackingCodeInjector
 
     private function hasValidConfiguration(Configuration $configuration): bool
     {
-        if (! \filter_var($configuration->url, \FILTER_VALIDATE_URL)) {
+        if (empty($configuration->url) || parse_url($configuration->url) === false) {
             return false;
         }
 

--- a/Tests/Unit/Hooks/PageRenderer/TrackingCodeInjectorTest.php
+++ b/Tests/Unit/Hooks/PageRenderer/TrackingCodeInjectorTest.php
@@ -285,6 +285,43 @@ final class TrackingCodeInjectorTest extends TestCase
     }
 
     #[Test]
+    public function executeAcceptsUrlWithRelativeProtocol(): void
+    {
+        $this->configureDefaultRequestStubForFrontend();
+
+        $this->pageRendererMock
+            ->expects(self::once())
+            ->method('addHeaderData')
+            ->with('<script>/* some tracking code */</script>');
+        $this->pageRendererMock
+            ->expects(self::never())
+            ->method('addFooterData');
+
+        $configuration = [
+            'matomoIntegrationUrl' => '//example.org/',
+            'matomoIntegrationSiteId' => 42,
+        ];
+
+        $this->siteStub
+            ->method('getConfiguration')
+            ->willReturn($configuration);
+
+        $this->javaScriptTrackingCodeBuilderStub
+            ->method('getTrackingCode')
+            ->willReturn('/* some tracking code */');
+
+        $subject = new TrackingCodeInjector(
+            $this->javaScriptTrackingCodeBuilderStub,
+            $this->noScriptTrackingCodeBuilderStub,
+            $this->tagManagerCodeBuilderStub,
+            $this->scriptTagBuilder,
+            new NoopEventDispatcher(),
+        );
+        $params = [];
+        $subject->execute($params, $this->pageRendererMock);
+    }
+
+    #[Test]
     public function ensureModifySiteConfigurationEventIsDispatched(): void
     {
         $this->configureDefaultRequestStubForFrontend();


### PR DESCRIPTION
This allows the `matomoIntegrationUrl` to use a relative protocol, e.g. `//example.org`. This is in line with the site `base` which also allows this.